### PR TITLE
release junit 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ public interface PlayerDao {
 <dependency>
     <groupId>com.github.arteam</groupId>
     <artifactId>jdit</artifactId>
-    <version>0.8</version>
+    <version>0.9</version>
     <scope>test</scope>
 </dependency>
 ```


### PR DESCRIPTION
I'm upgrading an app to JUnit 5, and see that jdit migrated 
from JUnit 4 `DBIRunner` to JUnit 5 `DBIExtension` in 2266d114a7c06f042e7fd15ff52075284088d9ae,
but that this has not been released:
https://github.com/arteam/jdit/blob/jdit-0.9/src/main/java/com/github/arteam/jdit/DBIRunner.java

https://github.com/arteam/jdit/blob/jdit-0.9/pom.xml#L20

https://github.com/arteam/jdit/blob/151fa225f0488ab0c52ace4b1bef998b561e5934/pom.xml#L20

Can this be released, please?